### PR TITLE
Allow backend image domains

### DIFF
--- a/front/next.config.mjs
+++ b/front/next.config.mjs
@@ -8,6 +8,20 @@ const nextConfig = {
   },
   images: {
     unoptimized: true,
+    remotePatterns: [
+      {
+        protocol: "http",
+        hostname: "127.0.0.1",
+        port: "8000",
+        pathname: "/**",
+      },
+      {
+        protocol: "http",
+        hostname: "localhost",
+        port: "8000",
+        pathname: "/**",
+      },
+    ],
   },
 }
 


### PR DESCRIPTION
## Summary
- enable Next.js to load images from `localhost:8000` and `127.0.0.1:8000`

## Testing
- `npm run lint --prefix front` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bcce9954832f8a64b6a98b2e1826