### PR TITLE
Allow backend image domains and return album media

### DIFF
--- a/back/app/Http/Controllers/Api/HomeApiController.php
+++ b/back/app/Http/Controllers/Api/HomeApiController.php
@@ -128,9 +128,9 @@ class HomeApiController extends Controller
             $lastPage = ceil($total / $perPage);
 
             // Get media for each album if table exists
-            if (DB::getSchemaBuilder()->hasTable('album_media')) {
+            if (DB::getSchemaBuilder()->hasTable('medias')) {
                 foreach ($albums as $album) {
-                    $media = DB::table('album_media')
+                    $media = DB::table('medias')
                         ->where('album_id', $album->id)
                         ->get();
                     $album->media = $media;
@@ -198,8 +198,8 @@ class HomeApiController extends Controller
             }
 
             // Get media for the album if table exists
-            if (DB::getSchemaBuilder()->hasTable('album_media')) {
-                $media = DB::table('album_media')
+            if (DB::getSchemaBuilder()->hasTable('medias')) {
+                $media = DB::table('medias')
                     ->where('album_id', $album->id)
                     ->get();
                 $album->media = $media;

--- a/back/app/Http/Controllers/HomeApiController.php
+++ b/back/app/Http/Controllers/HomeApiController.php
@@ -128,9 +128,9 @@ class HomeApiController extends Controller
             $lastPage = ceil($total / $perPage);
 
             // Get media for each album if table exists
-            if (DB::getSchemaBuilder()->hasTable('album_media')) {
+            if (DB::getSchemaBuilder()->hasTable('medias')) {
                 foreach ($albums as $album) {
-                    $media = DB::table('album_media')
+                    $media = DB::table('medias')
                         ->where('album_id', $album->id)
                         ->get();
                     $album->media = $media;
@@ -198,8 +198,8 @@ class HomeApiController extends Controller
             }
 
             // Get media for the album if table exists
-            if (DB::getSchemaBuilder()->hasTable('album_media')) {
-                $media = DB::table('album_media')
+            if (DB::getSchemaBuilder()->hasTable('medias')) {
+                $media = DB::table('medias')
                     ->where('album_id', $album->id)
                     ->get();
                 $album->media = $media;

--- a/front/next.config.mjs
+++ b/front/next.config.mjs
@@ -8,6 +8,20 @@ const nextConfig = {
   },
   images: {
     unoptimized: true,
+    remotePatterns: [
+      {
+        protocol: "http",
+        hostname: "127.0.0.1",
+        port: "8000",
+        pathname: "/**",
+      },
+      {
+        protocol: "http",
+        hostname: "localhost",
+        port: "8000",
+        pathname: "/**",
+      },
+    ],
   },
 }
 


### PR DESCRIPTION
## Summary
- enable Next.js to load images from `localhost:8000` and `127.0.0.1:8000`
- fetch album images from the `medias` table so galleries display photos

## Testing
- `php artisan test` *(fails: Command "test" is not defined)*
- `npm run lint --prefix front` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bcce9954832f8a64b6a98b2e1826