### PR TITLE
fix: load album images from configurable backend

### DIFF
--- a/front/components/album-grid.tsx
+++ b/front/components/album-grid.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { ChevronLeft, ChevronRight } from "lucide-react"
 import { motion } from "framer-motion"
 import { useLanguage } from "@/contexts/language-context"
+import { getBackendUrl } from "@/lib/utils"
 
 interface Album {
   id: number
@@ -95,7 +96,7 @@ export default function AlbumGrid() {
     if (!name || name.includes("placeholder")) {
       return `/placeholder.svg?height=192&width=384&query=album`
     }
-    return `http://127.0.0.1:8000/images/albums/${name}`
+    return `${getBackendUrl()}/images/albums/${name}`
   }
 
   if (error) {

--- a/front/components/photo-gallery.tsx
+++ b/front/components/photo-gallery.tsx
@@ -8,6 +8,7 @@ import { Dialog, DialogContent } from "@/components/ui/dialog"
 import { X, ChevronLeft, ChevronRight } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useLanguage } from "@/contexts/language-context"
+import { getBackendUrl } from "@/lib/utils"
 
 interface Media {
   id: number
@@ -61,7 +62,7 @@ export default function PhotoGallery({ media }: PhotoGalleryProps) {
     if (!name || name.includes("placeholder")) {
       return `/placeholder.svg?height=400&width=400&query=photo`
     }
-    return `http://127.0.0.1:8000/images/albums/${name}`
+    return `${getBackendUrl()}/images/albums/${name}`
   }
 
   return (

--- a/front/components/team-members.tsx
+++ b/front/components/team-members.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { motion } from "framer-motion"
 import { useLanguage } from "@/contexts/language-context"
+import { getBackendUrl } from "@/lib/utils"
 
 interface Member {
   id: number
@@ -63,7 +64,7 @@ export default function TeamMembers() {
     if (!image || image.includes("placeholder")) {
       return `/placeholder.svg?height=128&width=128&query=person`
     }
-    return `http://127.0.0.1:8000/images/members/${image}`
+    return `${getBackendUrl()}/images/members/${image}`
   }
 
   if (error) {

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -12,3 +12,7 @@ export function formatCurrency(amount: number): string {
     minimumFractionDigits: 2,
   }).format(amount)
 }
+
+export function getBackendUrl(): string {
+  return process.env.NEXT_PUBLIC_BACKEND_URL || "http://127.0.0.1:8000"
+}

--- a/front/next.config.mjs
+++ b/front/next.config.mjs
@@ -11,14 +11,12 @@ const nextConfig = {
     remotePatterns: [
       {
         protocol: "http",
-        hostname: "127.0.0.1",
-        port: "8000",
+        hostname: "**",
         pathname: "/**",
       },
       {
-        protocol: "http",
-        hostname: "localhost",
-        port: "8000",
+        protocol: "https",
+        hostname: "**",
         pathname: "/**",
       },
     ],


### PR DESCRIPTION
## Summary
- load album and member images from configurable backend URL
- widen allowed image hosts in Next.js config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c4ef59a4832fa34850f1a2074e1e