### PR TITLE
Add statistics to admin dashboard

### DIFF
--- a/back/app/Http/Controllers/UserController.php
+++ b/back/app/Http/Controllers/UserController.php
@@ -4,6 +4,11 @@ namespace App\Http\Controllers;
 
 use App\Models\Token;
 use App\Models\User;
+use App\Models\Albums;
+use App\Models\Members;
+use App\Models\Contact;
+use App\Models\Donation;
+use App\Models\Media;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
@@ -78,7 +83,17 @@ class UserController extends Controller
             'keywords' => 'dashboard, page',
         ];
 
-        return view('admin.auth.dashboard', compact('settings'));
+        $stats = [
+            'total_users' => User::count(),
+            'total_members' => Members::count(),
+            'total_albums' => Albums::count(),
+            'total_media' => Media::count(),
+            'total_queries' => Contact::count(),
+            'total_donations' => Donation::count(),
+            'total_donation_amount' => Donation::sum('amount'),
+        ];
+
+        return view('admin.auth.dashboard', compact('settings', 'stats'));
     }
 
     public function logout()

--- a/back/resources/views/admin/auth/dashboard.blade.php
+++ b/back/resources/views/admin/auth/dashboard.blade.php
@@ -63,6 +63,130 @@
                 </div>
             </div>
         </div>
+
+        @if(!empty($stats))
+        <div class="row">
+            <div class="col-sm-4">
+                <div class="card">
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col mt-0">
+                                <h5 class="card-title">Total Admins</h5>
+                            </div>
+                            <div class="col-auto">
+                                <div class="stat text-primary">
+                                    <i class="align-middle" data-feather="users"></i>
+                                </div>
+                            </div>
+                        </div>
+                        <h1 class="mt-1 mb-3">{{ $stats['total_users'] }}</h1>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-4">
+                <div class="card">
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col mt-0">
+                                <h5 class="card-title">Total Members</h5>
+                            </div>
+                            <div class="col-auto">
+                                <div class="stat text-primary">
+                                    <i class="align-middle" data-feather="user"></i>
+                                </div>
+                            </div>
+                        </div>
+                        <h1 class="mt-1 mb-3">{{ $stats['total_members'] }}</h1>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-4">
+                <div class="card">
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col mt-0">
+                                <h5 class="card-title">Total Albums</h5>
+                            </div>
+                            <div class="col-auto">
+                                <div class="stat text-primary">
+                                    <i class="align-middle" data-feather="book"></i>
+                                </div>
+                            </div>
+                        </div>
+                        <h1 class="mt-1 mb-3">{{ $stats['total_albums'] }}</h1>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-4">
+                <div class="card">
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col mt-0">
+                                <h5 class="card-title">Total Media</h5>
+                            </div>
+                            <div class="col-auto">
+                                <div class="stat text-primary">
+                                    <i class="align-middle" data-feather="image"></i>
+                                </div>
+                            </div>
+                        </div>
+                        <h1 class="mt-1 mb-3">{{ $stats['total_media'] }}</h1>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-4">
+                <div class="card">
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col mt-0">
+                                <h5 class="card-title">Total Queries</h5>
+                            </div>
+                            <div class="col-auto">
+                                <div class="stat text-primary">
+                                    <i class="align-middle" data-feather="help-circle"></i>
+                                </div>
+                            </div>
+                        </div>
+                        <h1 class="mt-1 mb-3">{{ $stats['total_queries'] }}</h1>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-4">
+                <div class="card">
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col mt-0">
+                                <h5 class="card-title">Total Donations</h5>
+                            </div>
+                            <div class="col-auto">
+                                <div class="stat text-primary">
+                                    <i class="align-middle" data-feather="heart"></i>
+                                </div>
+                            </div>
+                        </div>
+                        <h1 class="mt-1 mb-3">{{ $stats['total_donations'] }}</h1>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-4">
+                <div class="card">
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col mt-0">
+                                <h5 class="card-title">Donation Amount</h5>
+                            </div>
+                            <div class="col-auto">
+                                <div class="stat text-primary">
+                                    <i class="align-middle" data-feather="dollar-sign"></i>
+                                </div>
+                            </div>
+                        </div>
+                        <h1 class="mt-1 mb-3">${{ number_format($stats['total_donation_amount'], 2) }}</h1>
+                    </div>
+                </div>
+            </div>
+        </div>
+        @endif
     </div>
 @endsection
 


### PR DESCRIPTION
## Summary
- aggregate counts and donation totals in UserController and expose them to dashboard view
- render admin, member, album, media, query, donation, and amount stats on the dashboard

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `php artisan test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f8095fe8832f9000f32f93452a97