### PR TITLE
Fix backend contact submission storage issue

### DIFF
--- a/back/app/Http/Controllers/Api/QueriesApiController.php
+++ b/back/app/Http/Controllers/Api/QueriesApiController.php
@@ -35,7 +35,7 @@ class QueriesApiController extends Controller
             $validator = Validator::make($request->all(), [
                 'name' => 'required|string|max:50',
                 'email' => 'required|email',
-                'mobile' => 'required|string',
+                'mobile' => 'nullable|string',
                 'message' => 'required|string',
             ]);
 
@@ -48,9 +48,9 @@ class QueriesApiController extends Controller
                 ], 422);
             }
 
-            // Check if the contact table exists
-            if (!Schema::hasTable('contact')) {
-                Log::warning('Contact table does not exist');
+            // Check if the contacts table exists
+            if (!Schema::hasTable('contacts')) {
+                Log::warning('Contacts table does not exist');
                 return response()->json([
                     'success' => true,
                     'message' => 'Contact form submitted successfully (table not found, but validation passed)'


### PR DESCRIPTION
## Summary
- accept optional mobile numbers in contact form submissions
- fix table name check so contact entries are saved

## Testing
- `php artisan test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0f2e6ecc832fbf5cc6e667f0f5ad